### PR TITLE
Add GUI form Pester test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         shell: pwsh
         run: |
           gh --version
-          gh auth status || gh auth login --with-token <<< "$env:GH_TOKEN"
+          gh auth status || ($env:GH_TOKEN | gh auth login --with-token)
 
       - name: Run Pester tests
         shell: pwsh

--- a/Tests/Get-GitHubRepoZip.UI.Tests.ps1
+++ b/Tests/Get-GitHubRepoZip.UI.Tests.ps1
@@ -1,0 +1,20 @@
+#Requires -Version 5.1
+# Pester v5
+# Ensures GUI form and controls instantiate correctly.
+
+Describe 'Get-GitHubRepoZip UI basic construction' -Skip:([System.Environment]::OSVersion.Platform -ne 'Win32NT') {
+    It 'creates main form and controls without showing UI' {
+        $scriptPath = Join-Path $PSScriptRoot '..\Get-GitHubRepoZip.UI.ps1'
+        $content = Get-Content -Path $scriptPath -Raw
+        $content = $content -replace 'Test-GhAuth',''
+        $content = $content -replace '\$btnRefreshRepos\.PerformClick\(\)\s*\|\s*Out-Null',''
+        $content = $content -replace '\[void\]\$form\.ShowDialog\(\)',''
+        Invoke-Expression $content
+
+        $form | Should -Not -BeNullOrEmpty
+        $form.Text | Should -Be 'GitHub Repo ZIP Downloader'
+        $btnDownload | Should -Not -BeNullOrEmpty
+        $btnDownload.Text | Should -Be 'Download'
+        $form.Dispose()
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests to validate GUI form construction and controls
- document purpose of GUI test

## Testing
- ❌ `pwsh -NoProfile -Command "Invoke-Pester -Path ./Tests -CI"` (command not found: pwsh)


------
https://chatgpt.com/codex/tasks/task_e_68b5e1d563908320a0d93ef8be3034d4