### PR TITLE
Fix UI test path resolution for Get-GitHubRepoZip

### DIFF
--- a/Tests/Get-GitHubRepoZip.UI.Tests.ps1
+++ b/Tests/Get-GitHubRepoZip.UI.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Get-GitHubRepoZip UI basic construction' -Skip:([System.Environment]::
         $content = $content -replace 'Test-GhAuth',''
         $content = $content -replace '\$btnRefreshRepos\.PerformClick\(\)\s*\|\s*Out-Null',''
         $content = $content -replace '\[void\]\$form\.ShowDialog\(\)',''
+        $PSScriptRoot = Split-Path $scriptPath
         Invoke-Expression $content
 
         $form | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
## Summary
- ensure UI tests set `$PSScriptRoot` before invoking Get-GitHubRepoZip.UI.ps1 so that core script can be dot-sourced correctly

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path ./Tests -CI -Output Detailed"` *(fails: command not found: pwsh)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `snap install powershell --classic` *(fails: command not found: snap)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e97efaa8832093430e821876cfe6